### PR TITLE
Add php5-curl to ./installer_linux.sh

### DIFF
--- a/installer_linux.sh
+++ b/installer_linux.sh
@@ -69,7 +69,7 @@ check_configuration(){
 }
 
 install_php(){
-	sudo apt-get install php5 php5-cli php5-intl php-apc
+	sudo apt-get install php5 php5-cli php5-intl php-apc php5-curl
 }
 
 install_mysql(){


### PR DESCRIPTION
php5-curl extension absence was silently leading to inability of updating sensio/distribution-bundle to v3.0.6
